### PR TITLE
completed assignment 53

### DIFF
--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -15,6 +15,8 @@ class Post < ActiveRecord::Base
   # validates :topic, presence: true
   # validates :user, presence: true
 
+  after_create :create_vote
+
   def up_votes
     votes.where(value: 1).count
   end
@@ -43,6 +45,10 @@ class Post < ActiveRecord::Base
   end
 
   private
+
+  def create_vote
+    user.votes.create(post: self, value: 1)
+  end
 
   def render_as_markdown(markdown)
     renderer = Redcarpet::Render::HTML.new


### PR DESCRIPTION
@Enriikke so on this new line we're setting the post association to self. When we call the `create` method on `votes`, we're passing it the instance of `Vote` to .... what exactly? I would have expected this to work by updating specific attributes like `user_id` (and like it's currently doing with `value`). What does it mean to pass a reference to an object to something like `post:`? Obviously it's extracting the `post_id` but this seems a little different.